### PR TITLE
Typo caused failure on case-sensitive filesystems

### DIFF
--- a/lib/smartystreets_ruby_sdk/us_street/candidate.rb
+++ b/lib/smartystreets_ruby_sdk/us_street/candidate.rb
@@ -1,6 +1,6 @@
-require_relative 'Components'
-require_relative 'Metadata'
-require_relative 'Analysis'
+require_relative 'components'
+require_relative 'metadata'
+require_relative 'analysis'
 
 module USStreet
   class Candidate


### PR DESCRIPTION
See above.  Found when trying to run on heroku as my case insensitive Mac volume ran fine in development.