### PR TITLE
Add support for UnprocessableEntityError on 422 responses.

### DIFF
--- a/lib/smartystreets_ruby_sdk/status_code_sender.rb
+++ b/lib/smartystreets_ruby_sdk/status_code_sender.rb
@@ -25,6 +25,8 @@ module SmartyStreets
                            RequestEntityTooLargeError.new(REQUEST_ENTITY_TOO_LARGE)
                          when '400'
                            BadRequestError.new(BAD_REQUEST)
+                         when '422'
+                           UnprocessableEntityError.new(UNPROCESSABLE_ENTITY)
                          when '429'
                            TooManyRequestsError.new(TOO_MANY_REQUESTS)
                          when '500'

--- a/test/smartystreets_ruby_sdk/test_status_code_sender.rb
+++ b/test/smartystreets_ruby_sdk/test_status_code_sender.rb
@@ -58,6 +58,16 @@ class TestStatusCodeSender < Minitest::Test
     assert_equal(expected_response.error, response.error)
   end
 
+  def test_unprocessable_entity_error_given_for_422
+    expected_response = Response.new(nil, '422', SmartyStreets::UnprocessableEntityError.new(SmartyStreets::UNPROCESSABLE_ENTITY))
+    inner = MockSender.new(Response.new(nil, '422', nil))
+    sender = StatusCodeSender.new(inner)
+
+    response = sender.send(Request.new)
+
+    assert_equal(expected_response.error, response.error)
+  end
+
   def test_too_many_requests_error_given_for_429
     expected_response = Response.new(nil, '429', SmartyStreets::TooManyRequestsError.new(SmartyStreets::TOO_MANY_REQUESTS))
     inner = MockSender.new(Response.new(nil, '429', nil))


### PR DESCRIPTION
Mapping 422 to `UnprocessableEntityError` seems to have been missing from `StatusCodeSender`. This PR adds it and a test for it.