### PR TITLE
Don't retry on client errors.

### DIFF
--- a/lib/smartystreets_ruby_sdk/retry_sender.rb
+++ b/lib/smartystreets_ruby_sdk/retry_sender.rb
@@ -1,7 +1,7 @@
 module SmartyStreets
   class RetrySender
     MAX_BACKOFF_DURATION = 10
-    STATUS_OK = '200'.freeze
+    STATUS_INTERNAL_SERVER_ERROR = '500'.freeze
 
     def initialize(max_retries, inner, sleeper, logger)
       @max_retries = max_retries
@@ -14,7 +14,7 @@ module SmartyStreets
       response = @inner.send(request)
 
       (0..@max_retries-1).each do |i|
-        break if response.status_code == STATUS_OK
+        break if response.status_code < STATUS_INTERNAL_SERVER_ERROR
 
         backoff(i)
 

--- a/test/smartystreets_ruby_sdk/test_retry_sender.rb
+++ b/test/smartystreets_ruby_sdk/test_retry_sender.rb
@@ -15,8 +15,15 @@ class TestRetrySender < Minitest::Test
     assert_equal(1, inner.current_status_code_index)
   end
 
+  def test_client_error_does_not_retry
+    inner = FailingSender.new(['422'])
+    send_with_retry(5, inner, FakeSleeper.new)
+
+    assert_equal(1, inner.current_status_code_index)
+  end
+
   def test_retry_until_success
-    inner = FailingSender.new(%w(401 402 400 200 500))
+    inner = FailingSender.new(%w(500 500 500 200 500))
 
     send_with_retry(10, inner, FakeSleeper.new)
 
@@ -36,7 +43,7 @@ class TestRetrySender < Minitest::Test
   end
 
   def test_backoff_does_not_exceed_max
-    inner = FailingSender.new(%w(401 402 400 500 500 500 500 500 500 500 500 500 500 200))
+    inner = FailingSender.new(%w(500 500 500 500 500 500 500 500 500 500 500 500 500 200))
     sleeper = FakeSleeper.new
 
     send_with_retry(20, inner, sleeper)
@@ -52,4 +59,3 @@ def send_with_retry(retries, inner, sleeper)
 
   sender.send(request)
 end
-


### PR DESCRIPTION
Many error classes aren't likely to succeed when you try again and so they probably shouldn't be retried by default.

Errors I don't think will typically work if retried:
* 401 - BadCredentialsError
* 402 - PaymentRequiredError
* 413 - RequestEntityTooLargeError
* 400 - BadRequestError
* 422 - UnprocessableEntityError
* 429 - TooManyRequestsError

Errors which may work if retried:
* 500 - InternalServerError
* 503 - ServiceUnavailableError

This is based on the errors handled by `StatusCodeSender`, as you can see it groups neatly into 400 errors (client errors) and 500 errors (server errors).

This PR only retries anything less than 500. 

Depending on your API compatibility stance this could be a big backwards compatibility change but it's in line with typical usage of HTTP.