### PR TITLE
Encode query parameters.

### DIFF
--- a/lib/smartystreets_ruby_sdk/native_sender.rb
+++ b/lib/smartystreets_ruby_sdk/native_sender.rb
@@ -63,14 +63,7 @@ module SmartyStreets
     end
 
     def self.create_query(smarty_request)
-      query_string = ''
-
-      smarty_request.parameters.each do |key, value|
-        query_string.concat("&#{key}=#{value}")
-      end
-
-      query_string[0] = ''
-      query_string
+      URI.encode_www_form(smarty_request.parameters)
     end
 
     def self.set_custom_headers(smarty_headers, request)

--- a/test/smartystreets_ruby_sdk/test_native_sender.rb
+++ b/test/smartystreets_ruby_sdk/test_native_sender.rb
@@ -59,6 +59,20 @@ class TestNativeSender < Minitest::Test
     assert_equal('auth-id=testID&auth-token=testToken', query)
   end
 
+  def test_query_encodes_parameters
+    smarty_request = Request.new
+    smarty_request.url_prefix = 'http://localhost'
+    smarty_request.payload = 'Test Payload'
+    smarty_request.parameters = {
+      'needs_encoding' => '&foo=bar',
+      'unicode' => 'Sjömadsvägen'
+    }
+
+    query = NativeSender.create_query(smarty_request)
+
+    assert_equal('needs_encoding=%26foo%3Dbar&unicode=Sj%C3%B6madsv%C3%A4gen', query)
+  end
+
   def test_request_contains_correct_content
     smarty_request = Request.new
     smarty_request.url_prefix = 'http://localhost'


### PR DESCRIPTION
Was trying to run some international address lookups and got:

```
URI::InvalidURIError: URI must be ascii only
```