### PR TITLE
namespace address class

### DIFF
--- a/lib/smartystreets_ruby_sdk/us_extract/result.rb
+++ b/lib/smartystreets_ruby_sdk/us_extract/result.rb
@@ -13,7 +13,7 @@ module SmartyStreets
         @addresses = []
 
         addresses.each {|address|
-          @addresses.push(Address.new(address))
+          @addresses.push(SmartyStreets::USExtract::Address.new(address))
         }
       end
     end


### PR DESCRIPTION
Using a plain `Address` class as is, is dangerous. i would be willing to bet 90% of people who use this library call their local class that stores addresses `Address`, or at least would prefer to.

This just makes sure there are no calls to a top level `Address` from this library