### PR TITLE
Check if raw_candidates is nil before iterating

### DIFF
--- a/lib/smartystreets_ruby_sdk/international_street/client.rb
+++ b/lib/smartystreets_ruby_sdk/international_street/client.rb
@@ -50,8 +50,10 @@ module SmartyStreets
       def convert_candidates(raw_candidates)
         candidates = []
 
-        raw_candidates.each do |candidate|
-          candidates.push(Candidate.new(candidate))
+        unless raw_candidates.nil?
+          raw_candidates.each do |candidate|
+            candidates.push(Candidate.new(candidate))
+          end
         end
 
         candidates


### PR DESCRIPTION
### Purpose

To fix this error which occurs when raw_candidates arg is nil.

```
NoMethodError: undefined method `each' for nil:NilClass
  from smartystreets_ruby_sdk/international_street/client.rb:50:in `convert_candidates'
  from smartystreets_ruby_sdk/international_street/client.rb:20:in `send'
```

### Changes
- Check if raw_candidates is nil before iterating and appending to candidates array.