### PR TITLE
Soft default candidates to 5 when using enhanced matching

### DIFF
--- a/lib/smartystreets_ruby_sdk/us_street/client.rb
+++ b/lib/smartystreets_ruby_sdk/us_street/client.rb
@@ -47,8 +47,8 @@ module SmartyStreets
         converted_obj = []
         obj.each do |lookup|
           converted_lookup = {}
-          lookup.candidates = 5 if lookup.match == "enhanced" && lookup.candidates == 1
 
+          converted_lookup['candidates'] = 5 if lookup.match == "enhanced"
           converted_lookup['input_id'] = lookup.input_id
           converted_lookup['street'] = lookup.street
           converted_lookup['street2'] = lookup.street2


### PR DESCRIPTION
Previously it was impossible to set candidates to 1 if using
enhanced matching

Ref: #32 