### PR TITLE
Retry when there is a socket level timeout

### DIFF
--- a/lib/smartystreets_ruby_sdk/response.rb
+++ b/lib/smartystreets_ruby_sdk/response.rb
@@ -1,3 +1,6 @@
+require 'timeout'
+
+
 module SmartyStreets
   class Response
     attr_accessor :payload, :status_code, :header, :error
@@ -7,6 +10,10 @@ module SmartyStreets
       @status_code = status_code
       @header = header
       @error = error
+    end
+
+    def timeout?
+      @error.is_a?(TimeoutError)
     end
   end
 end

--- a/lib/smartystreets_ruby_sdk/retry_sender.rb
+++ b/lib/smartystreets_ruby_sdk/retry_sender.rb
@@ -16,7 +16,7 @@ module SmartyStreets
 
       (0..@max_retries-1).each do |i|
 
-        break if STATUS_TO_RETRY.include?(response.status_code.to_i) == false
+        break if !STATUS_TO_RETRY.include?(response.status_code.to_i) && !response.timeout?
 
         if response.status_code.to_i == STATUS_TOO_MANY_REQUESTS
           seconds_to_backoff = 10

--- a/test/smartystreets_ruby_sdk/test_retry_sender.rb
+++ b/test/smartystreets_ruby_sdk/test_retry_sender.rb
@@ -1,7 +1,9 @@
 require 'minitest/autorun'
+require 'timeout'
 require './test/mocks/failing_sender'
 require './test/mocks/fake_sleeper'
 require './test/mocks/fake_logger'
+require './test/mocks/mock_exception_sender'
 require './lib/smartystreets_ruby_sdk/request'
 require './lib/smartystreets_ruby_sdk/retry_sender'
 
@@ -91,6 +93,14 @@ class TestRetrySender < Minitest::Test
     assert_equal("Big Bad", response.error)
   end
 
+  def test_retry_timeout
+    exception = TimeoutError.new
+    inner = MockExceptionSender.new(exception)
+    sleeper = FakeSleeper.new
+
+    send_with_retry(10, inner, sleeper)
+    assert_equal([0,1,2,3,4,5,6,7,8,9], sleeper.sleep_durations)
+  end
 end
 
 def send_with_retry(retries, inner, sleeper)


### PR DESCRIPTION
Currently, timeouts are not retried as the status code is nil and the retry sender doesn't consider those as retryable errors. This change allows the client to transparently retry when a timeout error occurs at the socket level (e.g. Net::OpenTimeout and Net::ReadTimeout).