### PR TITLE
Sleep for one second after a 429 error before retrying

### DIFF
--- a/examples/international_example.rb
+++ b/examples/international_example.rb
@@ -38,7 +38,7 @@ class InternationalExample
     lookup.country = 'Brazil'
     lookup.postal_code = '02516-050'
 
-    candidates = client.send(lookup) # The candidates are also stored in the lookup's 'result' field.
+    candidates = client.send_lookup(lookup) # The candidates are also stored in the lookup's 'result' field.
 
     first_candidate = candidates[0]
     puts "Input ID: #{first_candidate.input_id}"

--- a/lib/smartystreets_ruby_sdk/retry_sender.rb
+++ b/lib/smartystreets_ruby_sdk/retry_sender.rb
@@ -14,7 +14,7 @@ module SmartyStreets
     def send(request)
       response = @inner.send(request)
 
-      (0..@max_retries-1).each do |i|
+      (1..@max_retries).each do |i|
 
         break if STATUS_TO_RETRY.include?(response.status_code.to_i) == false
 

--- a/test/smartystreets_ruby_sdk/international_street/test_international_client.rb
+++ b/test/smartystreets_ruby_sdk/international_street/test_international_client.rb
@@ -16,7 +16,7 @@ class TestInternationalClient < Minitest::Test
     client = Client.new(sender, serializer)
     lookup = Lookup.new('1', '2')
 
-    client.send(lookup)
+    client.send_lookup(lookup)
 
     assert_equal('1', sender.request.parameters['freeform'])
     assert_equal('2', sender.request.parameters['country'])
@@ -41,7 +41,7 @@ class TestInternationalClient < Minitest::Test
     lookup.administrative_area = '8'
     lookup.postal_code = '9'
 
-    client.send(lookup)
+    client.send_lookup(lookup)
 
     assert_equal('1234', sender.request.parameters['input_id'])
     assert_equal('0', sender.request.parameters['country'])
@@ -63,7 +63,7 @@ class TestInternationalClient < Minitest::Test
     client = Client.new(sender, nil)
 
     assert_raises SmartyStreets::UnprocessableEntityError do
-      client.send(Lookup.new)
+      client.send_lookup(Lookup.new)
     end
   end
 
@@ -73,7 +73,7 @@ class TestInternationalClient < Minitest::Test
     lookup = Lookup.new(nil, '0')
 
     assert_raises SmartyStreets::UnprocessableEntityError do
-      client.send(lookup)
+      client.send_lookup(lookup)
     end
   end
 
@@ -84,7 +84,7 @@ class TestInternationalClient < Minitest::Test
     lookup.address1 = '1'
 
     assert_raises SmartyStreets::UnprocessableEntityError do
-      client.send(lookup)
+      client.send_lookup(lookup)
     end
   end
 
@@ -96,7 +96,7 @@ class TestInternationalClient < Minitest::Test
     lookup.locality = '2'
 
     assert_raises SmartyStreets::UnprocessableEntityError do
-      client.send(lookup)
+      client.send_lookup(lookup)
     end
   end
 
@@ -108,7 +108,7 @@ class TestInternationalClient < Minitest::Test
     lookup.administrative_area = '2'
 
     assert_raises SmartyStreets::UnprocessableEntityError do
-      client.send(lookup)
+      client.send_lookup(lookup)
     end
   end
 
@@ -120,17 +120,17 @@ class TestInternationalClient < Minitest::Test
 
     lookup.country = '0'
     lookup.freeform = '1'
-    client.send(lookup)
+    client.send_lookup(lookup)
 
     lookup.freeform = nil
     lookup.address1 = '1'
     lookup.postal_code = '2'
-    client.send(lookup)
+    client.send_lookup(lookup)
 
     lookup.postal_code = nil
     lookup.locality = '3'
     lookup.administrative_area = '4'
-    client.send(lookup)
+    client.send_lookup(lookup)
   end
 
   def test_deserialize_called_with_response_body
@@ -140,7 +140,7 @@ class TestInternationalClient < Minitest::Test
     deserializer = FakeDeserializer.new({})
     client = Client.new(sender, deserializer)
 
-    client.send(Lookup.new('1', '2'))
+    client.send_lookup(Lookup.new('1', '2'))
 
     assert_equal(response.payload, deserializer.input)
   end
@@ -153,7 +153,7 @@ class TestInternationalClient < Minitest::Test
     deserializer = FakeDeserializer.new(raw_candidates)
     client = Client.new(sender, deserializer)
 
-    client.send(lookup)
+    client.send_lookup(lookup)
 
     assert_equal(expected_candidates[0].address1, lookup.result[0].address1)
     assert_equal(expected_candidates[1].address1, lookup.result[1].address1)

--- a/test/smartystreets_ruby_sdk/test_retry_sender.rb
+++ b/test/smartystreets_ruby_sdk/test_retry_sender.rb
@@ -38,7 +38,7 @@ class TestRetrySender < Minitest::Test
 
     assert(response)
     assert_equal(5, inner.current_status_code_index)
-    assert_equal([0,1,2,3], sleeper.sleep_durations)
+    assert_equal([1,2,3,4], sleeper.sleep_durations)
     assert_equal('500', response.status_code)
   end
 
@@ -48,7 +48,7 @@ class TestRetrySender < Minitest::Test
 
     send_with_retry(20, inner, sleeper)
 
-    assert_equal([0,1,2,3,4,5,6,7,8,9,10,10,10], sleeper.sleep_durations)
+    assert_equal([1,2,3,4,5,6,7,8,9,10,10,10,10], sleeper.sleep_durations)
   end
 
   def test_nil_status_does_not_retry
@@ -68,6 +68,14 @@ class TestRetrySender < Minitest::Test
   end
 
   def test_rate_limit_error_return
+    inner = FailingSender.new(%w(429), {'Retry-After' => 12})
+    sleeper = FakeSleeper.new
+
+    send_with_retry(10, inner, sleeper)
+    assert_equal([12], sleeper.sleep_durations)
+  end
+
+  def test_rate_limit_greater_than_10s
     inner = FailingSender.new(%w(429), {'Retry-After' => 7})
     sleeper = FakeSleeper.new
 


### PR DESCRIPTION
Updated functionality for sleeping after a 429 error from sleeping for 0 seconds after the first attempt to sleeping for 1 second after the first attempt. Updated international example and tests to use new send method.