### PR TITLE
Remove require for removed geolocation type file

### DIFF
--- a/lib/smartystreets_ruby_sdk/international_autocomplete.rb
+++ b/lib/smartystreets_ruby_sdk/international_autocomplete.rb
@@ -1,5 +1,4 @@
 require_relative './international_autocomplete/lookup'
-require_relative './international_autocomplete/international_geolocation_type'
 require_relative './international_autocomplete/suggestion'
 require_relative './international_autocomplete/client'
 


### PR DESCRIPTION
A file being required no longer exists.

See issue https://github.com/smartystreets/smartystreets-ruby-sdk/issues/45