### PR TITLE
make max candidates default for us-street-api be 1 - the same as the api itself.

### DIFF
--- a/lib/smartystreets_ruby_sdk/us_street/client.rb
+++ b/lib/smartystreets_ruby_sdk/us_street/client.rb
@@ -47,7 +47,7 @@ module SmartyStreets
         converted_obj = []
         obj.each do |lookup|
           converted_lookup = {}
-          lookup.candidates = 5 if lookup.match == "enhanced" && lookup.candidates == 0
+          lookup.candidates = 1 if lookup.match == "enhanced" && lookup.candidates == 0
 
           converted_lookup['input_id'] = lookup.input_id
           converted_lookup['street'] = lookup.street

--- a/test/smartystreets_ruby_sdk/us_street/test_street_client.rb
+++ b/test/smartystreets_ruby_sdk/us_street/test_street_client.rb
@@ -38,7 +38,7 @@ class TestStreetClient < Minitest::Test
         'addressee' => '9',
         'urbanization' => '10',
         'match' => SmartyStreets::USStreet::MatchType::ENHANCED,
-        'candidates' => 5,
+        'candidates' => 1,
         'format' => SmartyStreets::USStreet::OutputFormat::PROJECT_USA,
         'county_source' => SmartyStreets::USStreet::CountySource::GEOGRAPHIC,
         'parameter' => 'value',


### PR DESCRIPTION
make max candidates default for us-street-api be 1 - the same as the api itself.