### PR TITLE
Added three new fields to the Metadata struct: IANATimeZone (string), IANAUTCOffset (float32), and IANADST (bool). These three new fields are accessible via setting a new feature flag "iana-timezone" 

### DIFF
--- a/lib/smartystreets_ruby_sdk/client_builder.rb
+++ b/lib/smartystreets_ruby_sdk/client_builder.rb
@@ -154,9 +154,7 @@ module SmartyStreets
       self
     end
 
-    # Adds to the request query to use the IANA timezone feature.
-    #
-    # Returns self to accommodate method chaining.
+    # with_feature_iana_time_zone turns on the IANA timezone feature for the request.
     def with_feature_iana_time_zone()
       self.with_custom_comma_separated_query("features", "iana-timezone")
       self

--- a/lib/smartystreets_ruby_sdk/client_builder.rb
+++ b/lib/smartystreets_ruby_sdk/client_builder.rb
@@ -157,7 +157,7 @@ module SmartyStreets
     # Adds to the request query to use the IANA timezone feature.
     #
     # Returns self to accommodate method chaining.
-    def with_feature_iana_timezone()
+    def with_feature_iana_time_zone()
       self.with_custom_comma_separated_query("features", "iana-timezone")
       self
     end

--- a/lib/smartystreets_ruby_sdk/client_builder.rb
+++ b/lib/smartystreets_ruby_sdk/client_builder.rb
@@ -154,6 +154,14 @@ module SmartyStreets
       self
     end
 
+    # Adds to the request query to use the IANA timezone feature.
+    #
+    # Returns self to accommodate method chaining.
+    def with_feature_iana_timezone()
+      self.with_custom_comma_separated_query("features", "iana-timezone")
+      self
+    end
+
     # Enables debug mode, which will print information about the HTTP request and response to $stdout.
     #
     # Returns self to accommodate method chaining.

--- a/lib/smartystreets_ruby_sdk/us_street/metadata.rb
+++ b/lib/smartystreets_ruby_sdk/us_street/metadata.rb
@@ -4,7 +4,7 @@ module SmartyStreets
     class Metadata
       attr_reader :elot_sort, :longitude, :elot_sequence, :county_fips, :building_default_indicator, :rdi,
                   :congressional_district, :latitude, :precision, :time_zone, :zip_type, :county_name, :utc_offset,
-                  :record_type, :carrier_route, :obeys_dst, :iana_time_zone, :iana_utc_offset, :iana_dst,
+                  :record_type, :carrier_route, :obeys_dst, :iana_time_zone, :iana_utc_offset, :iana_obeys_dst,
                   :is_an_ews_match
 
       def initialize(obj)
@@ -26,7 +26,7 @@ module SmartyStreets
         @obeys_dst = obj['dst']
         @iana_time_zone = obj['iana_time_zone']
         @iana_utc_offset = obj['iana_utc_offset']
-        @iana_dst = obj['iana_dst']
+        @iana_obeys_dst = obj['iana_dst']
         @is_an_ews_match = obj['ews_match']
       end
     end

--- a/lib/smartystreets_ruby_sdk/us_street/metadata.rb
+++ b/lib/smartystreets_ruby_sdk/us_street/metadata.rb
@@ -4,7 +4,8 @@ module SmartyStreets
     class Metadata
       attr_reader :elot_sort, :longitude, :elot_sequence, :county_fips, :building_default_indicator, :rdi,
                   :congressional_district, :latitude, :precision, :time_zone, :zip_type, :county_name, :utc_offset,
-                  :record_type, :carrier_route, :obeys_dst, :is_an_ews_match
+                  :record_type, :carrier_route, :obeys_dst, :iana_time_zone, :iana_utc_offset, :iana_dst,
+                  :is_an_ews_match
 
       def initialize(obj)
         @record_type = obj['record_type']
@@ -23,6 +24,9 @@ module SmartyStreets
         @time_zone = obj['time_zone']
         @utc_offset = obj['utc_offset']
         @obeys_dst = obj['dst']
+        @iana_time_zone = obj['iana_time_zone']
+        @iana_utc_offset = obj['iana_utc_offset']
+        @iana_dst = obj['iana_dst']
         @is_an_ews_match = obj['ews_match']
       end
     end

--- a/test/smartystreets_ruby_sdk/test_client_builder.rb
+++ b/test/smartystreets_ruby_sdk/test_client_builder.rb
@@ -26,16 +26,16 @@ class TestClientBuilder < Minitest::Test
     assert_equal(client.instance_variable_get(:@queries)["features"], "component-analysis")
   end
 
-  def test_with_feature_iana_timezone
+  def test_with_feature_iana_time_zone
     client = SmartyStreets::ClientBuilder.new(SmartyStreets::SharedCredentials.new("key", "referer"))
-      .with_feature_iana_timezone()
+      .with_feature_iana_time_zone()
     assert_equal(client.instance_variable_get(:@queries)["features"], "iana-timezone")
   end
 
-  def test_with_feature_iana_timezone_and_component_analysis_should_append
+  def test_with_feature_iana_time_zone_and_component_analysis_should_append
     client = SmartyStreets::ClientBuilder.new(SmartyStreets::SharedCredentials.new("key", "referer"))
       .with_feature_component_analysis()
-      .with_feature_iana_timezone()
+      .with_feature_iana_time_zone()
     assert_equal(client.instance_variable_get(:@queries)["features"], "component-analysis,iana-timezone")
   end
 end

--- a/test/smartystreets_ruby_sdk/test_client_builder.rb
+++ b/test/smartystreets_ruby_sdk/test_client_builder.rb
@@ -25,4 +25,17 @@ class TestClientBuilder < Minitest::Test
       .with_feature_component_analysis()
     assert_equal(client.instance_variable_get(:@queries)["features"], "component-analysis")
   end
+
+  def test_with_feature_iana_timezone
+    client = SmartyStreets::ClientBuilder.new(SmartyStreets::SharedCredentials.new("key", "referer"))
+      .with_feature_iana_timezone()
+    assert_equal(client.instance_variable_get(:@queries)["features"], "iana-timezone")
+  end
+
+  def test_with_feature_iana_timezone_and_component_analysis_should_append
+    client = SmartyStreets::ClientBuilder.new(SmartyStreets::SharedCredentials.new("key", "referer"))
+      .with_feature_component_analysis()
+      .with_feature_iana_timezone()
+    assert_equal(client.instance_variable_get(:@queries)["features"], "component-analysis,iana-timezone")
+  end
 end

--- a/test/smartystreets_ruby_sdk/us_street/test_candidate.rb
+++ b/test/smartystreets_ruby_sdk/us_street/test_candidate.rb
@@ -56,7 +56,10 @@ class TestCandidate < Minitest::Test
         'time_zone' => '39',
         'utc_offset' => 40.0,
         'dst' => '41',
-        'ews_match' => '42'
+        'iana_time_zone' => '42',
+        'iana_utc_offset' => 43.0,
+        'iana_dst' => true,
+        'ews_match' => '44'
       },
       'analysis' => {
         'dpv_match_code' => '43',
@@ -138,7 +141,10 @@ class TestCandidate < Minitest::Test
     assert_equal('39', candidate.metadata.time_zone)
     assert_equal(40.0, candidate.metadata.utc_offset)
     assert_equal('41', candidate.metadata.obeys_dst)
-    assert_equal('42', candidate.metadata.is_an_ews_match)
+    assert_equal('42', candidate.metadata.iana_time_zone)
+    assert_equal(43.0, candidate.metadata.iana_utc_offset)
+    assert_equal(true, candidate.metadata.iana_dst)
+    assert_equal('44', candidate.metadata.is_an_ews_match)
 
     assert_equal('43', candidate.analysis.dpv_match_code)
     assert_equal('44', candidate.analysis.dpv_footnotes)

--- a/test/smartystreets_ruby_sdk/us_street/test_candidate.rb
+++ b/test/smartystreets_ruby_sdk/us_street/test_candidate.rb
@@ -143,7 +143,7 @@ class TestCandidate < Minitest::Test
     assert_equal('41', candidate.metadata.obeys_dst)
     assert_equal('42', candidate.metadata.iana_time_zone)
     assert_equal(43.0, candidate.metadata.iana_utc_offset)
-    assert_equal(true, candidate.metadata.iana_dst)
+    assert_equal(true, candidate.metadata.iana_obeys_dst)
     assert_equal('44', candidate.metadata.is_an_ews_match)
 
     assert_equal('43', candidate.analysis.dpv_match_code)


### PR DESCRIPTION
Added three new fields to the Metadata struct: IANATimeZone (string), IANAUTCOffset (float32), and IANADST (bool). These three new fields are accessible via setting a new feature flag "iana-timezone" 