### PR TITLE
Add with_sender() option with middleware 
  chain and conflict validation

### DIFF
--- a/lib/smartystreets_ruby_sdk/client_builder.rb
+++ b/lib/smartystreets_ruby_sdk/client_builder.rb
@@ -218,6 +218,13 @@ module SmartyStreets
     # </editor-fold>
 
     def build_sender
+      if @http_sender
+        conflicts = []
+        conflicts << 'with_max_timeout' if @max_timeout != 10
+        conflicts << 'with_proxy' if @proxy
+        conflicts << 'with_debug' if @debug
+        raise ArgumentError, "with_sender cannot be combined with: #{conflicts.join(', ')}. These options only apply to the built-in HTTP transport." unless conflicts.empty?
+      end
       sender = @http_sender || NativeSender.new(@max_timeout, @proxy, @debug)
 
       sender = StatusCodeSender.new(sender)

--- a/lib/smartystreets_ruby_sdk/client_builder.rb
+++ b/lib/smartystreets_ruby_sdk/client_builder.rb
@@ -39,7 +39,6 @@ module SmartyStreets
       @signer = signer
       @serializer = NativeSerializer.new
       @http_sender = nil
-      @wrapped_http_sender = nil
       @max_retries = 5
       @max_timeout = 10
       @url_prefix = nil
@@ -67,19 +66,11 @@ module SmartyStreets
       self
     end
 
-    # Default is a series of nested senders. (See build_sender()
+    # Sets the innermost HTTP transport sender while keeping the full middleware chain intact.
     #
     # Returns self to accommodate method chaining.
     def with_sender(sender)
       @http_sender = sender
-      self
-    end
-
-    # Replaces the innermost NativeSender while keeping the rest of the sender chain intact.
-    #
-    # Returns self to accommodate method chaining.
-    def with_wrapped_sender(sender)
-      @wrapped_http_sender = sender
       self
     end
 
@@ -227,9 +218,7 @@ module SmartyStreets
     # </editor-fold>
 
     def build_sender
-      return @http_sender unless @http_sender.nil?
-
-      sender = @wrapped_http_sender || NativeSender.new(@max_timeout, @proxy, @debug)
+      sender = @http_sender || NativeSender.new(@max_timeout, @proxy, @debug)
 
       sender = StatusCodeSender.new(sender)
 

--- a/lib/smartystreets_ruby_sdk/client_builder.rb
+++ b/lib/smartystreets_ruby_sdk/client_builder.rb
@@ -39,6 +39,7 @@ module SmartyStreets
       @signer = signer
       @serializer = NativeSerializer.new
       @http_sender = nil
+      @wrapped_http_sender = nil
       @max_retries = 5
       @max_timeout = 10
       @url_prefix = nil
@@ -71,6 +72,14 @@ module SmartyStreets
     # Returns self to accommodate method chaining.
     def with_sender(sender)
       @http_sender = sender
+      self
+    end
+
+    # Replaces the innermost NativeSender while keeping the rest of the sender chain intact.
+    #
+    # Returns self to accommodate method chaining.
+    def with_wrapped_sender(sender)
+      @wrapped_http_sender = sender
       self
     end
 
@@ -220,7 +229,7 @@ module SmartyStreets
     def build_sender
       return @http_sender unless @http_sender.nil?
 
-      sender = NativeSender.new(@max_timeout, @proxy, @debug)
+      sender = @wrapped_http_sender || NativeSender.new(@max_timeout, @proxy, @debug)
 
       sender = StatusCodeSender.new(sender)
 

--- a/test/smartystreets_ruby_sdk/test_client_builder.rb
+++ b/test/smartystreets_ruby_sdk/test_client_builder.rb
@@ -43,11 +43,11 @@ class TestClientBuilder < Minitest::Test
     assert_equal(client.instance_variable_get(:@queries)["features"], "component-analysis,iana-timezone")
   end
 
-  def test_with_wrapped_sender_wraps_with_middleware_chain
+  def test_with_sender_wraps_with_middleware_chain
     capturing_sender = RequestCapturingSender.new
     credentials = SmartyStreets::StaticCredentials.new("test-id", "test-token")
     client = SmartyStreets::ClientBuilder.new(credentials)
-      .with_wrapped_sender(capturing_sender)
+      .with_sender(capturing_sender)
       .build_us_street_api_client
 
     lookup = SmartyStreets::USStreet::Lookup.new

--- a/test/smartystreets_ruby_sdk/test_client_builder.rb
+++ b/test/smartystreets_ruby_sdk/test_client_builder.rb
@@ -2,6 +2,10 @@ require 'minitest/autorun'
 require_relative '../../lib/smartystreets_ruby_sdk/client_builder'
 require_relative '../../lib/smartystreets_ruby_sdk/response'
 require_relative '../../lib/smartystreets_ruby_sdk/request'
+require_relative '../../lib/smartystreets_ruby_sdk/static_credentials'
+require_relative '../../lib/smartystreets_ruby_sdk/shared_credentials'
+require_relative '../../lib/smartystreets_ruby_sdk/us_street/lookup'
+require_relative '../mocks/request_capturing_sender'
 
 class TestClientBuilder < Minitest::Test
   def test_with_custom_query
@@ -37,5 +41,21 @@ class TestClientBuilder < Minitest::Test
       .with_feature_component_analysis()
       .with_feature_iana_time_zone()
     assert_equal(client.instance_variable_get(:@queries)["features"], "component-analysis,iana-timezone")
+  end
+
+  def test_with_wrapped_sender_wraps_with_middleware_chain
+    capturing_sender = RequestCapturingSender.new
+    credentials = SmartyStreets::StaticCredentials.new("test-id", "test-token")
+    client = SmartyStreets::ClientBuilder.new(credentials)
+      .with_wrapped_sender(capturing_sender)
+      .build_us_street_api_client
+
+    lookup = SmartyStreets::USStreet::Lookup.new
+    lookup.street = "1 Rosedale"
+    client.send_lookup(lookup)
+
+    assert_includes(capturing_sender.request.url_prefix, "us-street.api.smarty.com")
+    assert_equal("test-id", capturing_sender.request.parameters["auth-id"])
+    assert_equal("test-token", capturing_sender.request.parameters["auth-token"])
   end
 end

--- a/test/smartystreets_ruby_sdk/test_client_builder.rb
+++ b/test/smartystreets_ruby_sdk/test_client_builder.rb
@@ -43,6 +43,22 @@ class TestClientBuilder < Minitest::Test
     assert_equal(client.instance_variable_get(:@queries)["features"], "component-analysis,iana-timezone")
   end
 
+  def test_with_sender_throws_when_combined_with_max_timeout
+    credentials = SmartyStreets::StaticCredentials.new("test-id", "test-token")
+    builder = SmartyStreets::ClientBuilder.new(credentials)
+      .with_sender(RequestCapturingSender.new)
+      .with_max_timeout(5)
+    assert_raises(ArgumentError) { builder.build_us_street_api_client }
+  end
+
+  def test_with_sender_throws_when_combined_with_proxy
+    credentials = SmartyStreets::StaticCredentials.new("test-id", "test-token")
+    builder = SmartyStreets::ClientBuilder.new(credentials)
+      .with_sender(RequestCapturingSender.new)
+      .with_proxy("localhost", 8080, nil, nil)
+    assert_raises(ArgumentError) { builder.build_us_street_api_client }
+  end
+
   def test_with_sender_wraps_with_middleware_chain
     capturing_sender = RequestCapturingSender.new
     credentials = SmartyStreets::StaticCredentials.new("test-id", "test-token")


### PR DESCRIPTION
## Summary
- Added `with_sender()` option to `ClientBuilder`, allowing a custom HTTP sender to 
  be used as the innermost transport while keeping the full middleware chain intact (signing, retries, status codes, headers, URL prefix, 
  license).
- Added an error when `with_sender()` is combined with `with_max_timeout()`, `with_proxy()`, or `with_debug()`, as these     
  options only apply to the built-in HTTP transport.

## Test plan
- [x] Existing tests pass
- [x] New tests verify the middleware  
  chain is applied when using `with_sender()`
- [x] New tests verify an error is raised when conflicting options are combined with       
  `with_sender()`