### PR TITLE
reverse-geo error handling updates and testing

### DIFF
--- a/lib/smartystreets_ruby_sdk/status_code_sender.rb
+++ b/lib/smartystreets_ruby_sdk/status_code_sender.rb
@@ -36,20 +36,14 @@ module SmartyStreets
       TooManyRequestsError.new(error_message)
     end
 
-    def fromMessage(response, fallback)
+    def from_message(response, fallback)
       return fallback if response.payload.nil?
 
-      error_message = ""
-      response_json = JSON.parse(response.payload)
-      errors = response_json["errors"]
-      if !errors.nil?
-        errors.each do |error|
-          error_message += (" " + error["message"])
-        end
-        error_message.strip!
-      end
+      errors = JSON.parse(response.payload)["errors"]
+      return fallback if errors.nil? || errors.empty?
 
-      error_message == "" ? fallback : error_message
+      message = errors.map { |error| error["message"] }.join(" ")
+      message.empty? ? fallback : message
     end
 
     def assign_exception(response)
@@ -57,15 +51,15 @@ module SmartyStreets
                          when '304'
                            NotModifiedInfo.new(NOT_MODIFIED, response.find_header('etag'))
                          when '401'
-                           BadCredentialsError.new(fromMessage(response, BAD_CREDENTIALS))
+                           BadCredentialsError.new(from_message(response, BAD_CREDENTIALS))
                          when '402'
-                           PaymentRequiredError.new(fromMessage(response, PAYMENT_REQUIRED))
+                           PaymentRequiredError.new(from_message(response, PAYMENT_REQUIRED))
                          when '413'
-                           RequestEntityTooLargeError.new(fromMessage(response, REQUEST_ENTITY_TOO_LARGE))
+                           RequestEntityTooLargeError.new(from_message(response, REQUEST_ENTITY_TOO_LARGE))
                          when '400'
-                           BadRequestError.new(fromMessage(response, BAD_REQUEST))
+                           BadRequestError.new(from_message(response, BAD_REQUEST))
                          when '422'
-                           UnprocessableEntityError.new(fromMessage(response, UNPROCESSABLE_ENTITY))
+                           UnprocessableEntityError.new(from_message(response, UNPROCESSABLE_ENTITY))
                          when '429'
                            TooManyRequestsError.new(TOO_MANY_REQUESTS)
                          when '500'

--- a/lib/smartystreets_ruby_sdk/status_code_sender.rb
+++ b/lib/smartystreets_ruby_sdk/status_code_sender.rb
@@ -1,3 +1,4 @@
+require 'json'
 require_relative 'exceptions'
 require_relative 'errors'
 
@@ -35,20 +36,36 @@ module SmartyStreets
       TooManyRequestsError.new(error_message)
     end
 
+    def fromMessage(response, fallback)
+      return fallback if response.payload.nil?
+
+      error_message = ""
+      response_json = JSON.parse(response.payload)
+      errors = response_json["errors"]
+      if !errors.nil?
+        errors.each do |error|
+          error_message += (" " + error["message"])
+        end
+        error_message.strip!
+      end
+
+      error_message == "" ? fallback : error_message
+    end
+
     def assign_exception(response)
       response.error = case response.status_code
                          when '304'
                            NotModifiedInfo.new(NOT_MODIFIED, response.find_header('etag'))
                          when '401'
-                           BadCredentialsError.new(BAD_CREDENTIALS)
+                           BadCredentialsError.new(fromMessage(response, BAD_CREDENTIALS))
                          when '402'
-                           PaymentRequiredError.new(PAYMENT_REQUIRED)
+                           PaymentRequiredError.new(fromMessage(response, PAYMENT_REQUIRED))
                          when '413'
-                           RequestEntityTooLargeError.new(REQUEST_ENTITY_TOO_LARGE)
+                           RequestEntityTooLargeError.new(fromMessage(response, REQUEST_ENTITY_TOO_LARGE))
                          when '400'
-                           BadRequestError.new(BAD_REQUEST)
+                           BadRequestError.new(fromMessage(response, BAD_REQUEST))
                          when '422'
-                           UnprocessableEntityError.new(UNPROCESSABLE_ENTITY)
+                           UnprocessableEntityError.new(fromMessage(response, UNPROCESSABLE_ENTITY))
                          when '429'
                            TooManyRequestsError.new(TOO_MANY_REQUESTS)
                          when '500'

--- a/test/smartystreets_ruby_sdk/test_status_code_sender.rb
+++ b/test/smartystreets_ruby_sdk/test_status_code_sender.rb
@@ -19,63 +19,113 @@ class TestStatusCodeSender < Minitest::Test
   end
 
   def test_bad_credentials_error_given_for_401
-    expected_exception = SmartyStreets::BadCredentialsError.new(SmartyStreets::BAD_CREDENTIALS)
-    expected_response = Response.new(nil, '401', nil, expected_exception)
-    inner = MockSender.new(Response.new(nil, '401', nil, expected_exception))
+    expected_exception = SmartyStreets::BadCredentialsError.new("These credentials are no good")
+    inner = MockSender.new(Response.new("{\"errors\": [{\"id\":\"1\", \"message\": \"These credentials are no good\"}]}", '401', nil, nil))
     sender = StatusCodeSender.new(inner)
 
     response = sender.send(Request.new)
 
-    assert_equal(expected_response.error, response.error)
-    assert_equal(response.error, expected_exception)
+    assert_equal(expected_exception, response.error)
+    assert_equal("These credentials are no good", response.error.message)
+  end
+
+  def test_bad_credentials_error_fallback_for_401
+    expected_exception = SmartyStreets::BadCredentialsError.new(SmartyStreets::BAD_CREDENTIALS)
+    inner = MockSender.new(Response.new(nil, '401', nil, nil))
+    sender = StatusCodeSender.new(inner)
+
+    response = sender.send(Request.new)
+
+    assert_equal(expected_exception, response.error)
+    assert_equal(SmartyStreets::BAD_CREDENTIALS, response.error.message)
   end
 
   def test_payment_required_error_given_for_402
-    expected_exception = SmartyStreets::PaymentRequiredError.new(SmartyStreets::PAYMENT_REQUIRED)
-    expected_response = Response.new(nil, '402', nil, expected_exception)
-    inner = MockSender.new(Response.new(nil, '402', nil, expected_exception))
+    expected_exception = SmartyStreets::PaymentRequiredError.new("Pay up please")
+    inner = MockSender.new(Response.new("{\"errors\": [{\"id\":\"2\", \"message\": \"Pay up please\"}]}", '402', nil, nil))
     sender = StatusCodeSender.new(inner)
 
     response = sender.send(Request.new)
 
-    assert_equal(expected_response.error, response.error)
-    assert_equal(response.error, expected_exception)
+    assert_equal(expected_exception, response.error)
+    assert_equal("Pay up please", response.error.message)
+  end
+
+  def test_payment_required_error_fallback_for_402
+    expected_exception = SmartyStreets::PaymentRequiredError.new(SmartyStreets::PAYMENT_REQUIRED)
+    inner = MockSender.new(Response.new(nil, '402', nil, nil))
+    sender = StatusCodeSender.new(inner)
+
+    response = sender.send(Request.new)
+
+    assert_equal(expected_exception, response.error)
+    assert_equal(SmartyStreets::PAYMENT_REQUIRED, response.error.message)
   end
 
   def test_request_entity_too_large_error_given_for_413
-    expected_exception = SmartyStreets::RequestEntityTooLargeError.new(SmartyStreets::REQUEST_ENTITY_TOO_LARGE)
-    expected_response = Response.new(nil, '413', nil, expected_exception)
-    inner = MockSender.new(Response.new(nil, '413', nil, expected_exception))
+    expected_exception = SmartyStreets::RequestEntityTooLargeError.new("That is way too big")
+    inner = MockSender.new(Response.new("{\"errors\": [{\"id\":\"3\", \"message\": \"That is way too big\"}]}", '413', nil, nil))
     sender = StatusCodeSender.new(inner)
 
     response = sender.send(Request.new)
 
-    assert_equal(expected_response.error, response.error)
-    assert_equal(response.error, expected_exception)
+    assert_equal(expected_exception, response.error)
+    assert_equal("That is way too big", response.error.message)
+  end
+
+  def test_request_entity_too_large_error_fallback_for_413
+    expected_exception = SmartyStreets::RequestEntityTooLargeError.new(SmartyStreets::REQUEST_ENTITY_TOO_LARGE)
+    inner = MockSender.new(Response.new(nil, '413', nil, nil))
+    sender = StatusCodeSender.new(inner)
+
+    response = sender.send(Request.new)
+
+    assert_equal(expected_exception, response.error)
+    assert_equal(SmartyStreets::REQUEST_ENTITY_TOO_LARGE, response.error.message)
   end
 
   def test_bad_request_error_given_for_400
+    expected_exception = SmartyStreets::BadRequestError.new("Your request was malformed")
+    inner = MockSender.new(Response.new("{\"errors\": [{\"id\":\"4\", \"message\": \"Your request was malformed\"}]}", '400', nil, nil))
+    sender = StatusCodeSender.new(inner)
+
+    response = sender.send(Request.new)
+
+    assert_equal(expected_exception, response.error)
+    assert_equal("Your request was malformed", response.error.message)
+  end
+
+  def test_bad_request_error_fallback_for_400
     expected_exception = SmartyStreets::BadRequestError.new(SmartyStreets::BAD_REQUEST)
-    expected_response = Response.new(nil, '400', nil, expected_exception)
     inner = MockSender.new(Response.new(nil, '400', nil, nil))
     sender = StatusCodeSender.new(inner)
 
     response = sender.send(Request.new)
 
-    assert_equal(expected_response.error, response.error)
-    assert_equal(response.error, expected_exception)
+    assert_equal(expected_exception, response.error)
+    assert_equal(SmartyStreets::BAD_REQUEST, response.error.message)
   end
 
   def test_unprocessable_entity_error_given_for_422
-    expected_exception = SmartyStreets::UnprocessableEntityError.new(SmartyStreets::UNPROCESSABLE_ENTITY)
-    expected_response = Response.new(nil, '422', nil, expected_exception)
-    inner = MockSender.new(Response.new(nil, '422', nil))
+    expected_exception = SmartyStreets::UnprocessableEntityError.new("Missing some fields")
+    inner = MockSender.new(Response.new("{\"errors\": [{\"id\":\"5\", \"message\": \"Missing some fields\"}]}", '422', nil, nil))
     sender = StatusCodeSender.new(inner)
 
     response = sender.send(Request.new)
 
-    assert_equal(expected_response.error, response.error)
-    assert_equal(response.error, expected_exception)
+    assert_equal(expected_exception, response.error)
+    assert_equal("Missing some fields", response.error.message)
+  end
+
+  def test_unprocessable_entity_error_fallback_for_422
+    expected_exception = SmartyStreets::UnprocessableEntityError.new(SmartyStreets::UNPROCESSABLE_ENTITY)
+    inner = MockSender.new(Response.new(nil, '422', nil, nil))
+    sender = StatusCodeSender.new(inner)
+
+    response = sender.send(Request.new)
+
+    assert_equal(expected_exception, response.error)
+    assert_equal(SmartyStreets::UNPROCESSABLE_ENTITY, response.error.message)
   end
 
   def test_too_many_requests_error_given_for_429


### PR DESCRIPTION
Added a fromMessage function to return either the fallback error message or the readable error from the request. Added testing to check.