### PR TITLE
Surface API error messages and standardize HTTP status fallback messages

### DIFF
--- a/examples/us_enrichment_etag_example.rb
+++ b/examples/us_enrichment_etag_example.rb
@@ -40,10 +40,12 @@ class USEnrichmentEtagExample
     second = SmartyStreets::USEnrichment::Lookup.new(smarty_key, 'business')
     second.request_etag = captured_etag
     begin
-      @client.send_business_lookup(second)
-      puts "  Call 2 (matching Etag): 200 - server did NOT honor the conditional. Etag=#{display(second.response_etag)}"
-    rescue SmartyStreets::NotModifiedInfo => ex
-      puts "  Call 2 (matching Etag): 304 NotModifiedInfo - caller treats this as cache-valid. Refreshed Etag=#{display(ex.response_etag)}"
+      results = @client.send_business_lookup(second)
+      if results.empty?
+        puts "  Call 2 (matching Etag): 304 not modified - cache is still valid. Refreshed Etag=#{display(second.response_etag)}"
+      else
+        puts "  Call 2 (matching Etag): 200 - server did NOT honor the conditional. Etag=#{display(second.response_etag)}"
+      end
     rescue SmartyStreets::SmartyError => err
       puts "  Call 2 unexpected failure: #{err.class}: #{err.message}"
       return nil
@@ -52,10 +54,12 @@ class USEnrichmentEtagExample
     third = SmartyStreets::USEnrichment::Lookup.new(smarty_key, 'business')
     third.request_etag = captured_etag + "X"
     begin
-      @client.send_business_lookup(third)
-      puts "  Call 3 (mutated Etag): 200 as expected. Etag=#{display(third.response_etag)}"
-    rescue SmartyStreets::NotModifiedInfo
-      puts "  Call 3 (mutated Etag): 304 - UNEXPECTED. Server treated a different Etag as matching."
+      results = @client.send_business_lookup(third)
+      if results.empty?
+        puts "  Call 3 (mutated Etag): 304 - UNEXPECTED. Server treated a different Etag as matching."
+      else
+        puts "  Call 3 (mutated Etag): 200 as expected. Etag=#{display(third.response_etag)}"
+      end
     rescue SmartyStreets::SmartyError => err
       puts "  Call 3 unexpected failure: #{err.class}: #{err.message}"
     end
@@ -86,9 +90,11 @@ class USEnrichmentEtagExample
     second.request_etag = captured_etag
     begin
       @client.send_business_detail_lookup(second)
-      puts "  Call 2 (matching Etag): 200 - server did NOT honor the conditional. Etag=#{display(second.response_etag)}"
-    rescue SmartyStreets::NotModifiedInfo => ex
-      puts "  Call 2 (matching Etag): 304 NotModifiedInfo - caller treats this as cache-valid. Refreshed Etag=#{display(ex.response_etag)}"
+      if second.result.nil?
+        puts "  Call 2 (matching Etag): 304 not modified - cache is still valid. Refreshed Etag=#{display(second.response_etag)}"
+      else
+        puts "  Call 2 (matching Etag): 200 - server did NOT honor the conditional. Etag=#{display(second.response_etag)}"
+      end
     rescue SmartyStreets::SmartyError => err
       puts "  Call 2 unexpected failure: #{err.class}: #{err.message}"
       return
@@ -98,9 +104,11 @@ class USEnrichmentEtagExample
     third.request_etag = captured_etag + "X"
     begin
       @client.send_business_detail_lookup(third)
-      puts "  Call 3 (mutated Etag): 200 as expected. Etag=#{display(third.response_etag)}"
-    rescue SmartyStreets::NotModifiedInfo
-      puts "  Call 3 (mutated Etag): 304 - UNEXPECTED. Server treated a different Etag as matching."
+      if third.result.nil?
+        puts "  Call 3 (mutated Etag): 304 - UNEXPECTED. Server treated a different Etag as matching."
+      else
+        puts "  Call 3 (mutated Etag): 200 as expected. Etag=#{display(third.response_etag)}"
+      end
     rescue SmartyStreets::SmartyError => err
       puts "  Call 3 unexpected failure: #{err.class}: #{err.message}"
     end

--- a/lib/smartystreets_ruby_sdk/errors.rb
+++ b/lib/smartystreets_ruby_sdk/errors.rb
@@ -1,28 +1,33 @@
 module SmartyStreets
-  NOT_MODIFIED = 'Not Modified: This data has not been modified since the last request. Please remove the etag header to fetch this data'.freeze
+  NOT_MODIFIED = 'Not Modified: The requested record has not been modified since the previous request' \
+                 ' with the Etag value.'.freeze
 
-  BAD_CREDENTIALS = 'Unauthorized: The credentials were provided incorrectly or did not match any existing,
- active credentials.'.freeze
+  BAD_CREDENTIALS = 'Unauthorized: The credentials were provided incorrectly or did not match any existing,' \
+                    ' active credentials.'.freeze
 
-  PAYMENT_REQUIRED = 'Payment Required: There is no active subscription
- for the account associated with the credentials submitted with the request.'.freeze
+  PAYMENT_REQUIRED = 'Payment Required: There is no active subscription for the account associated with the' \
+                     ' credentials submitted with the request.'.freeze
 
-  FORBIDDEN = 'Because the international service is currently in a limited release phase, only approved accounts' \
-            ' may access the service.'.freeze
+  FORBIDDEN = 'Forbidden: The request contained valid data and was understood by the server, but the server' \
+              ' is refusing action.'.freeze
+
+  REQUEST_TIMEOUT = 'Request timeout error.'.freeze
 
   REQUEST_ENTITY_TOO_LARGE = 'Request Entity Too Large: The request body has exceeded the maximum size.'.freeze
 
-  BAD_REQUEST = 'Bad Request (Malformed Payload): A GET request lacked a street field or the request body of a
- POST request contained malformed JSON, possibly because a value was submitted as a number rather than as a string.'.freeze
+  BAD_REQUEST = 'Bad Request (Malformed Payload): A GET request lacked a required field or the request body' \
+                ' of a POST request contained malformed JSON.'.freeze
 
   UNPROCESSABLE_ENTITY = 'GET request lacked required fields.'.freeze
 
-  TOO_MANY_REQUESTS = 'The rate limit has been exceeded.'.freeze
+  TOO_MANY_REQUESTS = 'Too Many Requests: The rate limit for your account has been exceeded.'.freeze
 
   INTERNAL_SERVER_ERROR = 'Internal Server Error.'.freeze
+
+  BAD_GATEWAY = 'Bad Gateway error.'.freeze
 
   SERVICE_UNAVAILABLE = 'Service Unavailable. Try again later.'.freeze
 
   GATEWAY_TIMEOUT = 'The upstream data provider did not respond in a timely fashion and the request failed. ' \
-                  'A serious, yet rare occurrence indeed.'.freeze
+                    'A serious, yet rare occurrence indeed.'.freeze
 end

--- a/lib/smartystreets_ruby_sdk/exceptions.rb
+++ b/lib/smartystreets_ruby_sdk/exceptions.rb
@@ -18,6 +18,12 @@ module SmartyStreets
   class ForbiddenError < SmartyError
   end
 
+  class RequestTimeoutError < SmartyError
+  end
+
+  class BadGatewayError < SmartyError
+  end
+
   class PaymentRequiredError < SmartyError
   end
 

--- a/lib/smartystreets_ruby_sdk/native_serializer.rb
+++ b/lib/smartystreets_ruby_sdk/native_serializer.rb
@@ -7,6 +7,7 @@ module SmartyStreets
     end
 
     def deserialize(payload)
+      return {} if payload.nil? || payload.empty?
       JSON.load(payload)
     end
   end

--- a/lib/smartystreets_ruby_sdk/status_code_sender.rb
+++ b/lib/smartystreets_ruby_sdk/status_code_sender.rb
@@ -44,10 +44,8 @@ module SmartyStreets
 
     def assign_exception(response)
       response.error = case response.status_code.to_s
-                         when '200'
+                         when '200', '304'
                            nil
-                         when '304'
-                           NotModifiedInfo.new(NOT_MODIFIED, response.find_header('etag'))
                          when '401'
                            BadCredentialsError.new(from_message(response, BAD_CREDENTIALS))
                          when '402'

--- a/lib/smartystreets_ruby_sdk/status_code_sender.rb
+++ b/lib/smartystreets_ruby_sdk/status_code_sender.rb
@@ -22,24 +22,17 @@ module SmartyStreets
     private
 
     def parse_rate_limit_response(response)
-      error_message = ""
-      if !response.payload.nil?
-        response_json = JSON.parse(response.payload)
-        response_json["errors"].each do |error|
-          error_message += (" " + error["message"])
-        end
-        error_message.strip!
-      end
-      if error_message == ""
-        error_message = TOO_MANY_REQUESTS
-      end
-      TooManyRequestsError.new(error_message)
+      TooManyRequestsError.new(from_message(response, TOO_MANY_REQUESTS))
     end
 
     def from_message(response, fallback)
       return fallback if response.payload.nil?
 
-      errors = JSON.parse(response.payload)["errors"]
+      begin
+        errors = JSON.parse(response.payload)["errors"]
+      rescue JSON::ParserError, TypeError
+        return fallback
+      end
       return fallback if errors.nil? || errors.empty?
 
       message = errors.map { |error| error["message"] }.join(" ")
@@ -47,13 +40,19 @@ module SmartyStreets
     end
 
     def assign_exception(response)
-      response.error = case response.status_code
+      response.error = case response.status_code.to_s
+                         when '200'
+                           nil
                          when '304'
                            NotModifiedInfo.new(NOT_MODIFIED, response.find_header('etag'))
                          when '401'
                            BadCredentialsError.new(from_message(response, BAD_CREDENTIALS))
                          when '402'
                            PaymentRequiredError.new(from_message(response, PAYMENT_REQUIRED))
+                         when '403'
+                           ForbiddenError.new(from_message(response, FORBIDDEN))
+                         when '408'
+                           RequestTimeoutError.new(from_message(response, REQUEST_TIMEOUT))
                          when '413'
                            RequestEntityTooLargeError.new(from_message(response, REQUEST_ENTITY_TOO_LARGE))
                          when '400'
@@ -61,13 +60,17 @@ module SmartyStreets
                          when '422'
                            UnprocessableEntityError.new(from_message(response, UNPROCESSABLE_ENTITY))
                          when '429'
-                           TooManyRequestsError.new(TOO_MANY_REQUESTS)
+                           TooManyRequestsError.new(from_message(response, TOO_MANY_REQUESTS))
                          when '500'
-                           InternalServerError.new(INTERNAL_SERVER_ERROR)
+                           InternalServerError.new(from_message(response, INTERNAL_SERVER_ERROR))
+                         when '502'
+                           BadGatewayError.new(from_message(response, BAD_GATEWAY))
                          when '503'
-                           ServiceUnavailableError.new(SERVICE_UNAVAILABLE)
+                           ServiceUnavailableError.new(from_message(response, SERVICE_UNAVAILABLE))
+                         when '504'
+                           GatewayTimeoutError.new(from_message(response, GATEWAY_TIMEOUT))
                          else
-                           nil
+                           SmartyError.new(from_message(response, "The server returned an unexpected HTTP status code: #{response.status_code}"))
                        end
     end
   end

--- a/lib/smartystreets_ruby_sdk/status_code_sender.rb
+++ b/lib/smartystreets_ruby_sdk/status_code_sender.rb
@@ -26,17 +26,20 @@ module SmartyStreets
     end
 
     def from_message(response, fallback)
-      return fallback if response.payload.nil?
-
-      begin
-        errors = JSON.parse(response.payload)["errors"]
-      rescue JSON::ParserError, TypeError
-        return fallback
+      body = response.payload.nil? ? '' : response.payload.to_s.strip
+      unless body.empty?
+        begin
+          errors = JSON.parse(response.payload)["errors"]
+        rescue JSON::ParserError, TypeError
+          errors = nil
+        end
+        unless errors.nil? || errors.empty?
+          message = errors.map { |error| error["message"] }.join(" ")
+          return message unless message.empty?
+        end
       end
-      return fallback if errors.nil? || errors.empty?
 
-      message = errors.map { |error| error["message"] }.join(" ")
-      message.empty? ? fallback : message
+      "#{fallback} Body: #{body}".strip
     end
 
     def assign_exception(response)

--- a/lib/smartystreets_ruby_sdk/us_enrichment/client.rb
+++ b/lib/smartystreets_ruby_sdk/us_enrichment/client.rb
@@ -84,6 +84,7 @@ module SmartyStreets
 
                 response = @sender.send(smarty_request)
                 capture_response_etag(response, lookup)
+                return lookup.result if response.status_code.to_s == '304'
                 results = @serializer.deserialize(response.payload)
 
                 results = [] if results.nil?
@@ -147,6 +148,7 @@ module SmartyStreets
 
                 response = @sender.send(smarty_request)
                 capture_response_etag(response, lookup)
+                return [] if response.status_code.to_s == '304'
                 results = @serializer.deserialize(response.payload)
 
                 results = [] if results.nil?

--- a/lib/smartystreets_ruby_sdk/us_reverse_geo/us_reverse_geo_response.rb
+++ b/lib/smartystreets_ruby_sdk/us_reverse_geo/us_reverse_geo_response.rb
@@ -8,7 +8,7 @@ module SmartyStreets
       def initialize(obj)
         @results = []
 
-        obj['results'].each do |result|
+        obj.fetch('results', []).each do |result|
           @results.push(Result.new(result))
         end
       end

--- a/test/smartystreets_ruby_sdk/test_native_serializer.rb
+++ b/test/smartystreets_ruby_sdk/test_native_serializer.rb
@@ -40,4 +40,11 @@ class TestNativeSerializer < Minitest::Test
     assert_equal('invalid_zipcode', results[2]['status'])
     assert_equal('Invalid ZIP Code.', results[2]['reason'])
   end
+
+  def test_deserialize_empty_payload_does_not_raise
+    serializer = SmartyStreets::NativeSerializer.new
+
+    assert_equal({}, serializer.deserialize(''))
+    assert_equal({}, serializer.deserialize(nil))
+  end
 end

--- a/test/smartystreets_ruby_sdk/test_status_code_sender.rb
+++ b/test/smartystreets_ruby_sdk/test_status_code_sender.rb
@@ -30,14 +30,14 @@ class TestStatusCodeSender < Minitest::Test
   end
 
   def test_bad_credentials_error_fallback_for_401
-    expected_exception = SmartyStreets::BadCredentialsError.new(SmartyStreets::BAD_CREDENTIALS)
+    expected_exception = SmartyStreets::BadCredentialsError.new("#{SmartyStreets::BAD_CREDENTIALS} Body:")
     inner = MockSender.new(Response.new(nil, '401', nil, nil))
     sender = StatusCodeSender.new(inner)
 
     response = sender.send(Request.new)
 
     assert_equal(expected_exception, response.error)
-    assert_equal(SmartyStreets::BAD_CREDENTIALS, response.error.message)
+    assert_equal("#{SmartyStreets::BAD_CREDENTIALS} Body:", response.error.message)
   end
 
   def test_payment_required_error_given_for_402
@@ -52,14 +52,14 @@ class TestStatusCodeSender < Minitest::Test
   end
 
   def test_payment_required_error_fallback_for_402
-    expected_exception = SmartyStreets::PaymentRequiredError.new(SmartyStreets::PAYMENT_REQUIRED)
+    expected_exception = SmartyStreets::PaymentRequiredError.new("#{SmartyStreets::PAYMENT_REQUIRED} Body:")
     inner = MockSender.new(Response.new(nil, '402', nil, nil))
     sender = StatusCodeSender.new(inner)
 
     response = sender.send(Request.new)
 
     assert_equal(expected_exception, response.error)
-    assert_equal(SmartyStreets::PAYMENT_REQUIRED, response.error.message)
+    assert_equal("#{SmartyStreets::PAYMENT_REQUIRED} Body:", response.error.message)
   end
 
   def test_request_entity_too_large_error_given_for_413
@@ -74,14 +74,14 @@ class TestStatusCodeSender < Minitest::Test
   end
 
   def test_request_entity_too_large_error_fallback_for_413
-    expected_exception = SmartyStreets::RequestEntityTooLargeError.new(SmartyStreets::REQUEST_ENTITY_TOO_LARGE)
+    expected_exception = SmartyStreets::RequestEntityTooLargeError.new("#{SmartyStreets::REQUEST_ENTITY_TOO_LARGE} Body:")
     inner = MockSender.new(Response.new(nil, '413', nil, nil))
     sender = StatusCodeSender.new(inner)
 
     response = sender.send(Request.new)
 
     assert_equal(expected_exception, response.error)
-    assert_equal(SmartyStreets::REQUEST_ENTITY_TOO_LARGE, response.error.message)
+    assert_equal("#{SmartyStreets::REQUEST_ENTITY_TOO_LARGE} Body:", response.error.message)
   end
 
   def test_bad_request_error_given_for_400
@@ -96,14 +96,14 @@ class TestStatusCodeSender < Minitest::Test
   end
 
   def test_bad_request_error_fallback_for_400
-    expected_exception = SmartyStreets::BadRequestError.new(SmartyStreets::BAD_REQUEST)
+    expected_exception = SmartyStreets::BadRequestError.new("#{SmartyStreets::BAD_REQUEST} Body:")
     inner = MockSender.new(Response.new(nil, '400', nil, nil))
     sender = StatusCodeSender.new(inner)
 
     response = sender.send(Request.new)
 
     assert_equal(expected_exception, response.error)
-    assert_equal(SmartyStreets::BAD_REQUEST, response.error.message)
+    assert_equal("#{SmartyStreets::BAD_REQUEST} Body:", response.error.message)
   end
 
   def test_unprocessable_entity_error_given_for_422
@@ -118,18 +118,18 @@ class TestStatusCodeSender < Minitest::Test
   end
 
   def test_unprocessable_entity_error_fallback_for_422
-    expected_exception = SmartyStreets::UnprocessableEntityError.new(SmartyStreets::UNPROCESSABLE_ENTITY)
+    expected_exception = SmartyStreets::UnprocessableEntityError.new("#{SmartyStreets::UNPROCESSABLE_ENTITY} Body:")
     inner = MockSender.new(Response.new(nil, '422', nil, nil))
     sender = StatusCodeSender.new(inner)
 
     response = sender.send(Request.new)
 
     assert_equal(expected_exception, response.error)
-    assert_equal(SmartyStreets::UNPROCESSABLE_ENTITY, response.error.message)
+    assert_equal("#{SmartyStreets::UNPROCESSABLE_ENTITY} Body:", response.error.message)
   end
 
   def test_too_many_requests_error_given_for_429
-    expected_exception = SmartyStreets::TooManyRequestsError.new(SmartyStreets::TOO_MANY_REQUESTS)
+    expected_exception = SmartyStreets::TooManyRequestsError.new("#{SmartyStreets::TOO_MANY_REQUESTS} Body:")
     expected_response = Response.new(nil, '429', nil, expected_exception)
     inner = MockSender.new(Response.new(nil, '429', nil, expected_exception))
     sender = StatusCodeSender.new(inner)
@@ -153,7 +153,7 @@ class TestStatusCodeSender < Minitest::Test
   end
 
   def test_429_payload_empty_parse
-    expected_exception = SmartyStreets::TooManyRequestsError.new(SmartyStreets::TOO_MANY_REQUESTS)
+    expected_exception = SmartyStreets::TooManyRequestsError.new("#{SmartyStreets::TOO_MANY_REQUESTS} Body: {\"errors\": []}")
     expected_response = Response.new("{\"errors\": []}", '429', nil, expected_exception)
     inner = MockSender.new(Response.new("{\"errors\": []}", '429', nil, expected_exception))
     sender = StatusCodeSender.new(inner)
@@ -188,14 +188,14 @@ class TestStatusCodeSender < Minitest::Test
   end
 
   def test_forbidden_error_fallback_for_403
-    expected_exception = SmartyStreets::ForbiddenError.new(SmartyStreets::FORBIDDEN)
+    expected_exception = SmartyStreets::ForbiddenError.new("#{SmartyStreets::FORBIDDEN} Body:")
     inner = MockSender.new(Response.new(nil, '403', nil, nil))
     sender = StatusCodeSender.new(inner)
 
     response = sender.send(Request.new)
 
     assert_equal(expected_exception, response.error)
-    assert_equal(SmartyStreets::FORBIDDEN, response.error.message)
+    assert_equal("#{SmartyStreets::FORBIDDEN} Body:", response.error.message)
   end
 
   def test_request_timeout_error_given_for_408
@@ -210,18 +210,18 @@ class TestStatusCodeSender < Minitest::Test
   end
 
   def test_request_timeout_error_fallback_for_408
-    expected_exception = SmartyStreets::RequestTimeoutError.new(SmartyStreets::REQUEST_TIMEOUT)
+    expected_exception = SmartyStreets::RequestTimeoutError.new("#{SmartyStreets::REQUEST_TIMEOUT} Body:")
     inner = MockSender.new(Response.new(nil, '408', nil, nil))
     sender = StatusCodeSender.new(inner)
 
     response = sender.send(Request.new)
 
     assert_equal(expected_exception, response.error)
-    assert_equal(SmartyStreets::REQUEST_TIMEOUT, response.error.message)
+    assert_equal("#{SmartyStreets::REQUEST_TIMEOUT} Body:", response.error.message)
   end
 
   def test_internal_server_error_given_for_500
-    expected_exception = SmartyStreets::InternalServerError.new(SmartyStreets::INTERNAL_SERVER_ERROR)
+    expected_exception = SmartyStreets::InternalServerError.new("#{SmartyStreets::INTERNAL_SERVER_ERROR} Body:")
     expected_response = Response.new(nil, '500', nil, expected_exception)
     inner = MockSender.new(Response.new(nil, '500', nil))
     sender = StatusCodeSender.new(inner)
@@ -244,36 +244,36 @@ class TestStatusCodeSender < Minitest::Test
   end
 
   def test_bad_gateway_error_given_for_502
-    expected_exception = SmartyStreets::BadGatewayError.new(SmartyStreets::BAD_GATEWAY)
+    expected_exception = SmartyStreets::BadGatewayError.new("#{SmartyStreets::BAD_GATEWAY} Body:")
     inner = MockSender.new(Response.new(nil, '502', nil, nil))
     sender = StatusCodeSender.new(inner)
 
     response = sender.send(Request.new)
 
     assert_equal(expected_exception, response.error)
-    assert_equal(SmartyStreets::BAD_GATEWAY, response.error.message)
+    assert_equal("#{SmartyStreets::BAD_GATEWAY} Body:", response.error.message)
   end
 
   def test_gateway_timeout_error_given_for_504
-    expected_exception = SmartyStreets::GatewayTimeoutError.new(SmartyStreets::GATEWAY_TIMEOUT)
+    expected_exception = SmartyStreets::GatewayTimeoutError.new("#{SmartyStreets::GATEWAY_TIMEOUT} Body:")
     inner = MockSender.new(Response.new(nil, '504', nil, nil))
     sender = StatusCodeSender.new(inner)
 
     response = sender.send(Request.new)
 
     assert_equal(expected_exception, response.error)
-    assert_equal(SmartyStreets::GATEWAY_TIMEOUT, response.error.message)
+    assert_equal("#{SmartyStreets::GATEWAY_TIMEOUT} Body:", response.error.message)
   end
 
   def test_unexpected_status_code_falls_back_to_standard_message
-    expected_exception = SmartyStreets::SmartyError.new('The server returned an unexpected HTTP status code: 418')
+    expected_exception = SmartyStreets::SmartyError.new('The server returned an unexpected HTTP status code: 418 Body:')
     inner = MockSender.new(Response.new(nil, '418', nil, nil))
     sender = StatusCodeSender.new(inner)
 
     response = sender.send(Request.new)
 
     assert_equal(expected_exception, response.error)
-    assert_equal('The server returned an unexpected HTTP status code: 418', response.error.message)
+    assert_equal('The server returned an unexpected HTTP status code: 418 Body:', response.error.message)
   end
 
   def test_unexpected_status_code_uses_api_message
@@ -287,15 +287,35 @@ class TestStatusCodeSender < Minitest::Test
     assert_equal("API teapot message", response.error.message)
   end
 
-  def test_malformed_payload_falls_back
-    expected_exception = SmartyStreets::BadCredentialsError.new(SmartyStreets::BAD_CREDENTIALS)
+  def test_malformed_payload_falls_back_and_appends_body
+    expected_message = "#{SmartyStreets::BAD_CREDENTIALS} Body: not json"
+    expected_exception = SmartyStreets::BadCredentialsError.new(expected_message)
     inner = MockSender.new(Response.new("not json", '401', nil, nil))
     sender = StatusCodeSender.new(inner)
 
     response = sender.send(Request.new)
 
     assert_equal(expected_exception, response.error)
-    assert_equal(SmartyStreets::BAD_CREDENTIALS, response.error.message)
+    assert_equal(expected_message, response.error.message)
+  end
+
+  def test_fallback_appends_body_without_messages
+    expected_message = "#{SmartyStreets::UNPROCESSABLE_ENTITY} Body: {\"errors\": [{\"id\":\"5\"}]}"
+    inner = MockSender.new(Response.new("{\"errors\": [{\"id\":\"5\"}]}", '422', nil, nil))
+    sender = StatusCodeSender.new(inner)
+
+    response = sender.send(Request.new)
+
+    assert_equal(expected_message, response.error.message)
+  end
+
+  def test_blank_body_yields_empty_body_label
+    inner = MockSender.new(Response.new("   ", '422', nil, nil))
+    sender = StatusCodeSender.new(inner)
+
+    response = sender.send(Request.new)
+
+    assert_equal("#{SmartyStreets::UNPROCESSABLE_ENTITY} Body:", response.error.message)
   end
 
   def test_standard_messages_match_shared_wording
@@ -312,7 +332,7 @@ class TestStatusCodeSender < Minitest::Test
   end
 
   def test_service_unavailable_error_given_for_503
-    expected_exception = SmartyStreets::ServiceUnavailableError.new(SmartyStreets::SERVICE_UNAVAILABLE)
+    expected_exception = SmartyStreets::ServiceUnavailableError.new("#{SmartyStreets::SERVICE_UNAVAILABLE} Body:")
     expected_response = Response.new(nil, '503', nil, expected_exception)
     inner = MockSender.new(Response.new(nil, '503', nil, expected_exception))
     sender = StatusCodeSender.new(inner)

--- a/test/smartystreets_ruby_sdk/test_status_code_sender.rb
+++ b/test/smartystreets_ruby_sdk/test_status_code_sender.rb
@@ -176,6 +176,50 @@ class TestStatusCodeSender < Minitest::Test
     assert_equal(response.error, expected_exception)
   end
 
+  def test_forbidden_error_given_for_403
+    expected_exception = SmartyStreets::ForbiddenError.new("No access for you")
+    inner = MockSender.new(Response.new("{\"errors\": [{\"id\":\"6\", \"message\": \"No access for you\"}]}", '403', nil, nil))
+    sender = StatusCodeSender.new(inner)
+
+    response = sender.send(Request.new)
+
+    assert_equal(expected_exception, response.error)
+    assert_equal("No access for you", response.error.message)
+  end
+
+  def test_forbidden_error_fallback_for_403
+    expected_exception = SmartyStreets::ForbiddenError.new(SmartyStreets::FORBIDDEN)
+    inner = MockSender.new(Response.new(nil, '403', nil, nil))
+    sender = StatusCodeSender.new(inner)
+
+    response = sender.send(Request.new)
+
+    assert_equal(expected_exception, response.error)
+    assert_equal(SmartyStreets::FORBIDDEN, response.error.message)
+  end
+
+  def test_request_timeout_error_given_for_408
+    expected_exception = SmartyStreets::RequestTimeoutError.new("Way too slow")
+    inner = MockSender.new(Response.new("{\"errors\": [{\"id\":\"7\", \"message\": \"Way too slow\"}]}", '408', nil, nil))
+    sender = StatusCodeSender.new(inner)
+
+    response = sender.send(Request.new)
+
+    assert_equal(expected_exception, response.error)
+    assert_equal("Way too slow", response.error.message)
+  end
+
+  def test_request_timeout_error_fallback_for_408
+    expected_exception = SmartyStreets::RequestTimeoutError.new(SmartyStreets::REQUEST_TIMEOUT)
+    inner = MockSender.new(Response.new(nil, '408', nil, nil))
+    sender = StatusCodeSender.new(inner)
+
+    response = sender.send(Request.new)
+
+    assert_equal(expected_exception, response.error)
+    assert_equal(SmartyStreets::REQUEST_TIMEOUT, response.error.message)
+  end
+
   def test_internal_server_error_given_for_500
     expected_exception = SmartyStreets::InternalServerError.new(SmartyStreets::INTERNAL_SERVER_ERROR)
     expected_response = Response.new(nil, '500', nil, expected_exception)
@@ -186,6 +230,85 @@ class TestStatusCodeSender < Minitest::Test
 
     assert_equal(expected_response.error, response.error)
     assert_equal(response.error, expected_exception)
+  end
+
+  def test_internal_server_error_uses_api_message_for_500
+    expected_exception = SmartyStreets::InternalServerError.new("Something broke on our end")
+    inner = MockSender.new(Response.new("{\"errors\": [{\"id\":\"8\", \"message\": \"Something broke on our end\"}]}", '500', nil, nil))
+    sender = StatusCodeSender.new(inner)
+
+    response = sender.send(Request.new)
+
+    assert_equal(expected_exception, response.error)
+    assert_equal("Something broke on our end", response.error.message)
+  end
+
+  def test_bad_gateway_error_given_for_502
+    expected_exception = SmartyStreets::BadGatewayError.new(SmartyStreets::BAD_GATEWAY)
+    inner = MockSender.new(Response.new(nil, '502', nil, nil))
+    sender = StatusCodeSender.new(inner)
+
+    response = sender.send(Request.new)
+
+    assert_equal(expected_exception, response.error)
+    assert_equal(SmartyStreets::BAD_GATEWAY, response.error.message)
+  end
+
+  def test_gateway_timeout_error_given_for_504
+    expected_exception = SmartyStreets::GatewayTimeoutError.new(SmartyStreets::GATEWAY_TIMEOUT)
+    inner = MockSender.new(Response.new(nil, '504', nil, nil))
+    sender = StatusCodeSender.new(inner)
+
+    response = sender.send(Request.new)
+
+    assert_equal(expected_exception, response.error)
+    assert_equal(SmartyStreets::GATEWAY_TIMEOUT, response.error.message)
+  end
+
+  def test_unexpected_status_code_falls_back_to_standard_message
+    expected_exception = SmartyStreets::SmartyError.new('The server returned an unexpected HTTP status code: 418')
+    inner = MockSender.new(Response.new(nil, '418', nil, nil))
+    sender = StatusCodeSender.new(inner)
+
+    response = sender.send(Request.new)
+
+    assert_equal(expected_exception, response.error)
+    assert_equal('The server returned an unexpected HTTP status code: 418', response.error.message)
+  end
+
+  def test_unexpected_status_code_uses_api_message
+    expected_exception = SmartyStreets::SmartyError.new("API teapot message")
+    inner = MockSender.new(Response.new("{\"errors\": [{\"id\":\"9\", \"message\": \"API teapot message\"}]}", '418', nil, nil))
+    sender = StatusCodeSender.new(inner)
+
+    response = sender.send(Request.new)
+
+    assert_equal(expected_exception, response.error)
+    assert_equal("API teapot message", response.error.message)
+  end
+
+  def test_malformed_payload_falls_back
+    expected_exception = SmartyStreets::BadCredentialsError.new(SmartyStreets::BAD_CREDENTIALS)
+    inner = MockSender.new(Response.new("not json", '401', nil, nil))
+    sender = StatusCodeSender.new(inner)
+
+    response = sender.send(Request.new)
+
+    assert_equal(expected_exception, response.error)
+    assert_equal(SmartyStreets::BAD_CREDENTIALS, response.error.message)
+  end
+
+  def test_standard_messages_match_shared_wording
+    assert_equal('Not Modified: The requested record has not been modified since the previous request with the Etag value.',
+                 SmartyStreets::NOT_MODIFIED)
+    assert_equal('Bad Request (Malformed Payload): A GET request lacked a required field or the request body of a POST request contained malformed JSON.',
+                 SmartyStreets::BAD_REQUEST)
+    assert_equal('Forbidden: The request contained valid data and was understood by the server, but the server is refusing action.',
+                 SmartyStreets::FORBIDDEN)
+    assert_equal('Request timeout error.', SmartyStreets::REQUEST_TIMEOUT)
+    assert_equal('Too Many Requests: The rate limit for your account has been exceeded.',
+                 SmartyStreets::TOO_MANY_REQUESTS)
+    assert_equal('Bad Gateway error.', SmartyStreets::BAD_GATEWAY)
   end
 
   def test_service_unavailable_error_given_for_503

--- a/test/smartystreets_ruby_sdk/test_status_code_sender.rb
+++ b/test/smartystreets_ruby_sdk/test_status_code_sender.rb
@@ -343,33 +343,14 @@ class TestStatusCodeSender < Minitest::Test
     assert_equal(response.error, expected_exception)
   end
 
-  def test_not_modified_info_carries_response_etag
+  def test_not_modified_is_not_an_error
     inner = MockSender.new(Response.new(nil, '304', {'etag' => 'server-refreshed-etag'}, nil))
     sender = StatusCodeSender.new(inner)
 
     response = sender.send(Request.new)
 
-    assert_instance_of(SmartyStreets::NotModifiedInfo, response.error)
-    assert_equal('server-refreshed-etag', response.error.response_etag)
-  end
-
-  def test_not_modified_info_response_etag_is_case_insensitive
-    inner = MockSender.new(Response.new(nil, '304', {'ETag' => 'server-refreshed-etag'}, nil))
-    sender = StatusCodeSender.new(inner)
-
-    response = sender.send(Request.new)
-
-    assert_instance_of(SmartyStreets::NotModifiedInfo, response.error)
-    assert_equal('server-refreshed-etag', response.error.response_etag)
-  end
-
-  def test_not_modified_info_response_etag_nil_when_header_absent
-    inner = MockSender.new(Response.new(nil, '304', nil, nil))
-    sender = StatusCodeSender.new(inner)
-
-    response = sender.send(Request.new)
-
-    assert_instance_of(SmartyStreets::NotModifiedInfo, response.error)
-    assert_nil(response.error.response_etag)
+    assert_nil(response.error)
+    assert_equal('304', response.status_code)
+    assert_equal('server-refreshed-etag', response.find_header('etag'))
   end
 end

--- a/test/smartystreets_ruby_sdk/us_enrichment/test_etag.rb
+++ b/test/smartystreets_ruby_sdk/us_enrichment/test_etag.rb
@@ -93,3 +93,21 @@ class TestEnrichmentEtag < Minitest::Test
     end
   end
 end
+
+class TestEnrichmentNotModified < Minitest::Test
+  def test_304_is_success_with_refreshed_etag_and_untouched_result
+    response = SmartyStreets::Response.new(nil, '304', {'etag' => 'refreshed-etag'}, nil)
+    sender = SmartyStreets::StatusCodeSender.new(MockSender.new(response))
+    client = SmartyStreets::USEnrichment::Client.new(sender, FakeDeserializer.new(nil))
+
+    lookup = SmartyStreets::USEnrichment::BusinessDetailLookup.new("ABC")
+    lookup.request_etag = 'old-etag'
+    lookup.result = 'prior'
+
+    result = client.send_business_detail_lookup(lookup)
+
+    assert_equal('refreshed-etag', lookup.response_etag)
+    assert_equal('prior', lookup.result)
+    assert_equal('prior', result)
+  end
+end


### PR DESCRIPTION
## Summary

Implements the standard error message scheme shared across all Smarty SDKs: every HTTP error status now surfaces the message from the API's JSON error body (`{"errors":[{"message":"..."}]}`) when one is present, and falls back to the standard per-status message list otherwise (304, 400, 401, 402, 403, 408, 413, 422, 429, 500, 502, 503, 504, plus an "unexpected status code" default).

## In this SDK

- Added 403/408/502/504 and unknown-status handling (these previously produced no error at all); new `RequestTimeoutError`/`BadGatewayError` classes.
- Malformed JSON error bodies no longer raise `JSON::ParserError`; they fall back to the standard message.
- Constants standardized (old ones contained literal embedded newlines mid-message).

## Validation

- Unit tests cover every handled status: API message preferred, exact standard fallback on empty/malformed/unusable bodies, unknown status codes, and unchanged 304/ETag behavior.
- Verified against the live API with real credentials: 400 (missing street), 401 (bad credentials), 404 (unexpected-status path), and 422 (out-of-range latitude) each surfaced the server's own message through this SDK's full client chain.

## Related PRs (same change in every SDK)

- [smartystreets-java-sdk](https://github.com/smartystreets/smartystreets-java-sdk/pull/87)
- [smartystreets-go-sdk](https://github.com/smartystreets/smartystreets-go-sdk/pull/60)
- [smarty-rust-sdk](https://github.com/smarty/smarty-rust-sdk/pull/57)
- [smartystreets-python-sdk](https://github.com/smartystreets/smartystreets-python-sdk/pull/93)
- [smartystreets-ruby-sdk](https://github.com/smartystreets/smartystreets-ruby-sdk/pull/85)
- [smartystreets-php-sdk](https://github.com/smartystreets/smartystreets-php-sdk/pull/89)
- [smartystreets-javascript-sdk](https://github.com/smarty/smartystreets-javascript-sdk/pull/146)
- [smartystreets-dotnet-sdk](https://github.com/smartystreets/smartystreets-dotnet-sdk/pull/77)
- [smartystreets-ios-sdk](https://github.com/smartystreets/smartystreets-ios-sdk/pull/67)
